### PR TITLE
Pass chart object to text() function

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,7 @@ function drawDoughnutLabel(chart, options) {
 
 		var innerLabels = [];
 		options.labels.forEach(function(label) {
-			var text = typeof(label.text) === 'function' ?  label.text() :  label.text;
+			var text = typeof(label.text) === 'function' ? label.text(chart) :  label.text;
 			var innerLabel = {
 				text: text,
 				font: utils.parseFont(resolve([label.font, options.font, {}], ctx, 0)),


### PR DESCRIPTION
In order to update the text of the label it is helpful to have the chart object, i.e. to get the total count of the chart segments.
This is similar to other Chart.js plugins.